### PR TITLE
Support null with strings

### DIFF
--- a/src/StringToExpression/Util/ExpressionConversions.cs
+++ b/src/StringToExpression/Util/ExpressionConversions.cs
@@ -103,13 +103,30 @@ namespace StringToExpression.Util
             }
             else if (IsNullConstant(exp1))
             {
-                //one of our expressions is null, so convert the other side to a nullable
-                commonType = typeof(Nullable<>).MakeGenericType(type2);
+                // strings are already nullables
+                if (type2 == typeof(string))
+                {
+                    commonType = type2;
+                }
+                else
+                {
+                    //one of our expressions is null, so convert the other side to a nullable
+                    commonType = typeof(Nullable<>).MakeGenericType(type2);
+                }
             }
             else if (IsNullConstant(exp2))
             {
-                //the other side of the expression is null so convert the first side to a nullable
-                commonType = typeof(Nullable<>).MakeGenericType(type1);
+                // strings are already nullables
+                if (type1 == typeof(string))
+                {
+                    commonType = type1;
+                }
+                else
+                {
+                    //the other side of the expression is null so convert the first side to a nullable
+                    commonType = typeof(Nullable<>).MakeGenericType(type1);
+                }
+                
             }
             else if (TryGetCommonType(type1, type2, out commonType))
             {

--- a/tests/StringToExpression.Test/Languages/ODataFilter/Fixtures/LinqToQuerystringTestDataFixture.cs
+++ b/tests/StringToExpression.Test/Languages/ODataFilter/Fixtures/LinqToQuerystringTestDataFixture.cs
@@ -87,7 +87,7 @@ namespace StringToExpression.Test.Fixtures
             NullableCollection = new List<NullableClass>
             {
                 InstanceBuilders.BuildNull(),
-                InstanceBuilders.BuildNull(1, new DateTime(2002, 01, 01), true, 10000000000, 111.111, 111.111f, 0x00, guidArray[0])
+                InstanceBuilders.BuildNull(1, new DateTime(2002, 01, 01), true, 10000000000, 111.111, 111.111f, 0x00, guidArray[0], "Dogfood")
             }.AsQueryable();
         }
 
@@ -113,9 +113,9 @@ namespace StringToExpression.Test.Fixtures
                 return new NullableClass();
             }
 
-            public static NullableClass BuildNull(int? age, DateTime? date, bool? complete, long? population, double? value, float? cost, byte? code, Guid? guid)
+            public static NullableClass BuildNull(int? age, DateTime? date, bool? complete, long? population, double? value, float? cost, byte? code, Guid? guid, string name)
             {
-                return new NullableClass { Date = date, Age = age, Complete = complete, Population = population, Value = value, Cost = cost, Code = code, Guid = guid };
+                return new NullableClass { Date = date, Age = age, Complete = complete, Population = population, Value = value, Cost = cost, Code = code, Guid = guid, Name = name };
             }
         }
 
@@ -200,6 +200,8 @@ namespace StringToExpression.Test.Fixtures
         public class NullableClass
         {
             public int? Id { get; set; }
+
+            public string Name { get; set; }
 
             public DateTime? Date { get; set; }
 

--- a/tests/StringToExpression.Test/Languages/ODataFilter/LinqToQuerystringEquivalenceTests.cs
+++ b/tests/StringToExpression.Test/Languages/ODataFilter/LinqToQuerystringEquivalenceTests.cs
@@ -209,6 +209,10 @@ namespace StringToExpression.Test
         [InlineData("Cost eq 111.111f")]
         [InlineData("Code eq 0x00")]
         [InlineData("Guid eq guid'" + LinqToQuerystringTestDataFixture.guid0 + "'")]
+        [InlineData("Name eq null")]
+        [InlineData("null eq Name")]
+        [InlineData("Name ne null")]
+        [InlineData("null ne Name")]
         public void When_nullable_data_should_return_same_results_as_linqToQuerystring(string query)
         {
             var linqToQuerystringFiltered = Data.NullableCollection.LinqToQuerystring("?$filter=" + query).ToList();

--- a/tests/StringToExpression.Test/StringToExpression.Test.csproj
+++ b/tests/StringToExpression.Test/StringToExpression.Test.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="LinqToQuerystring" Version="0.7.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello, I'm using your library and I had a problem filtering null strings, for instance, **Name eq null** did not work.

This PR adds the support for strings nullables comparison and also fix a vsstudio test adapter bug with xunit.